### PR TITLE
Add support for validate_with [PRC]

### DIFF
--- a/t/git-issue-2-validate-with.t
+++ b/t/git-issue-2-validate-with.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+
+use Params::Validate::Dependencies qw( validate_with all_of one_of );
+
+use Test::More;
+use Test::Exception;
+END { done_testing(); }
+
+sub doc { Params::Validate::Dependencies::document(@_) }
+
+my $spec = { foo => 1, bar => 1, optional => 0 };
+
+# Vanilla call
+is_deeply +{
+        validate_with(
+            params      => [ foo => 'foo', bar => 'bar', extra => 'extra' ],
+            spec        => $spec,
+            allow_extra => 1,
+        ),
+    },
+    { foo => 'foo', bar => 'bar', extra => 'extra' },
+    'Vanilla call';
+
+dies_ok {;
+        validate_with(
+            params       => [ foo => 'foo', bar => 'bar' ],
+            spec         => $spec,
+            dependencies => all_of(qw( foo optional )),
+        )
+    }
+    'Dies if dependency is not met';
+
+is_deeply +{
+        validate_with(
+            params       => [ foo => 'foo', bar => 'bar' ],
+            spec         => $spec,
+            dependencies => [ one_of('foo'), one_of('bar') ],
+        )
+    },
+    { foo => 'foo', bar => 'bar' },
+    'Supports multiple dependencies';
+
+is_deeply +{
+        validate_with(
+            params => [ foo => 'foo', bar => 'bar' ],
+            spec   => $spec,
+        )
+    },
+    { foo => 'foo', bar => 'bar' },
+    'Lives without dependencies';
+
+is_deeply +{
+        validate_with(
+            params       => [ foo => 'foo', bar => 'bar', optional => 1 ],
+            spec         => $spec,
+            dependencies => all_of(qw( foo optional )),
+        )
+    },
+    { foo => 'foo', bar => 'bar', optional => 1 },
+    'Lives when dependency is met';


### PR DESCRIPTION
This adds an override for `validate_with` called with a single dependency as

    # Will fail
    validate_with(
        params       => [ foo => 'foo', bar => 'bar' ],
        spec         => { foo => 1, bar => 1, optional => 0 },
        dependencies => all_of(qw( foo optional )),
    );

or with an array of them as 

    validate_with(
        params       => [ foo => 'foo', bar => 'bar' ],
        spec         => { foo => 1, bar => 1, optional => 0 },
        dependencies => [ one_of('foo'), one_of('bar') ],
    );

This PR brought to you courtesy of the PRC.
