### PR TITLE
Accept a hashref as first arg for validate [PRC]

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
     'Clone',            => 0.38,
     'Test::Differences' => 0,
     'Test::More'        => 0.88, # done_testing
+    'Test::Warnings'    => 0.026,
     'Test::Exception'   => 0,
     # Modern Data::Domain only works on 5.10 and higher
     (($] > 5.010) ? ('Data::Domain' => 1.02) : ()),

--- a/lib/Params/Validate/Dependencies.pm
+++ b/lib/Params/Validate/Dependencies.pm
@@ -121,7 +121,14 @@ Overrides and extends Params::Validate's function of the same name.
 =cut
 
 sub validate (\@@) {
-  my @args = @{shift()};
+  my @args;
+
+  my $p = shift;
+  if ( ref $p eq 'ARRAY' ) {
+    # First argument might have been a hash reference
+    @args = @{ ref $p->[0] ? [ %{ $p->[0] } ] : $p  };
+  }
+
   my $pv_spec;
   if(ref($_[0]) && ref($_[0]) =~ /HASH/) {
     $pv_spec = shift;

--- a/t/git-issue-3-hashref-warning.t
+++ b/t/git-issue-3-hashref-warning.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warnings;
+
+use Params::Validate::Dependencies qw( validate SCALAR );
+
+END { done_testing(); }
+
+sub foo { validate( @_, { bar => { type => SCALAR } } ) }
+
+my %params = ( bar => 'baz' );
+
+is_deeply +{ foo(%params) }, \%params, 'Params::Validate::Dependencies with list';
+
+is_deeply +{ foo(\%params) }, \%params, 'Params::Validate::Dependencies with hashref';


### PR DESCRIPTION
This makes the behaviour of the overriden `validate` more closely resemble that of the original package's.

Since we are testing for the absence of a warning, this does include adding a test dependency on Test::Warnings, but this could be removed if the test was redesigned.

This fixes #3.