### PR TITLE
Improve error reporting of failed validations [PRC]

### DIFF
--- a/lib/Params/Validate/Dependencies.pm
+++ b/lib/Params/Validate/Dependencies.pm
@@ -133,7 +133,8 @@ sub validate (\@@) {
   %rval = Params::Validate::validate(@args, $pv_spec) if($pv_spec);
 
   foreach (@coderefs) {
-    die("code-ref checking failed\n") unless($_->({@args}));
+    die 'code-ref checking failed: arguments were not ' . document($_) . "\n"
+        unless $_->({@args});
   }
 
   return wantarray ? %rval : \%rval;


### PR DESCRIPTION
This is an attempt at improving the error reporting when calls to `validation` fail, to address #7.

This maintains most of the existing error message, but extends it by appending the result of calling `document` on the failed coderef.

The result is something like this:

```
$ perl -Ilib -E '
    use Params::Validate::Dependencies qw( :all ); 
    my @args = ( foo => 1 ); 
    validate( 
        @args, 
        { 
            foo => 0, 
            bar => 0,
        }, 
        one_of( all_of("foo"), all_of("bar") )
    );
'
code-ref checking failed: arguments were not one of (all of ('foo') or all of ('bar'))
```
Keeping the existing part of the error message meant that the tests did not need to be changed. :tada: 
